### PR TITLE
Remove deprecated use of file method

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ utilities. It also requires the following non-core modules:
 * Moose
 * Moose::Role:
 * Moose::Util::TypeConstraints
-* MooseX::Types::Path::Class
-* Path::Class
+* MooseX::Types::Path::Tiny
+* Path::Tiny
 * namespace::autoclean
 
 Copyright and License

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Or, if you don't have Module::Build installed, type the following:
 Dependencies
 ------------
 
-This module requires the the [gettext](http://www.gnu.org/software/gettext/)
+This module requires the [gettext](http://www.gnu.org/software/gettext/)
 utilities. It also requires the following non-core modules:
 
 * Dist::Zilla

--- a/lib/Dist/Zilla/App/Command/msg_compile.pm
+++ b/lib/Dist/Zilla/App/Command/msg_compile.pm
@@ -5,10 +5,9 @@ package Dist::Zilla::App::Command::msg_compile;
 use Dist::Zilla::App -command;
 use strict;
 use warnings;
-use Path::Class;
+use Path::Tiny qw(path cwd);
 use Dist::Zilla::Plugin::LocaleTextDomain;
 use IPC::Run3;
-use File::Path 2.07 qw(make_path);
 use namespace::autoclean;
 
 our $VERSION = '0.91';
@@ -37,7 +36,7 @@ sub validate_args {
     }
 
     if ( my $dir = $opt->{dest_dir} ) {
-        $opt->{dest_dir} = dir $dir;
+        $opt->{dest_dir} = path $dir;
     }
 }
 
@@ -55,7 +54,7 @@ sub execute {
         or $self->zilla->log_fatal('LocaleTextDomain plugin not found in dist.ini!');
 
     my $lang_dir = $plugin->lang_dir;
-    my $dest_dir = $opt->{dest_dir} || dir;
+    my $dest_dir = $opt->{dest_dir} || cwd;
     my $lang_ext = $plugin->lang_file_suffix;
     my $bin_ext  = $plugin->bin_file_suffix;
     my $txt_dom  = $plugin->textdomain;
@@ -72,14 +71,14 @@ sub execute {
     my @pos = @{ $args } ? @{ $args } : $self->_po_files( $plugin );
     $plugin->log_fatal("No language catalog files found") unless @pos;
 
-    make_path $dest_dir->stringify;
+    $dest_dir->mkpath;
 
     for my $file (@pos) {
-        $file = file $file;
+        $file = path $file;
         ( my $lang = $file->basename ) =~ s{[.][^.]*$}{};
-        my $dest = file $dest_dir, 'LocaleData', $lang, 'LC_MESSAGES',
-            "$txt_dom.$bin_ext";
-        make_path $dest->dir->stringify;
+        my $dest = $dest_dir->child('LocaleData', $lang, 'LC_MESSAGES',
+            "$txt_dom.$bin_ext");
+        $dest->parent->mkpath;
         run3 [@cmd, $dest, $file], undef, $log, $log;
         $plugin->log_fatal("Cannot compile $file") if $?;
     }

--- a/lib/Dist/Zilla/App/Command/msg_init.pm
+++ b/lib/Dist/Zilla/App/Command/msg_init.pm
@@ -5,7 +5,6 @@ package Dist::Zilla::App::Command::msg_init;
 use Dist::Zilla::App -command;
 use strict;
 use warnings;
-use Path::Class;
 use Dist::Zilla::Plugin::LocaleTextDomain;
 use Moose;
 use IPC::Run3;
@@ -99,7 +98,7 @@ sub execute {
     for my $lang (@{ $args }) {
         # Strip off encoding.
         (my $name = $lang) =~ s/[.].+$//;
-        my $dest = $lang_dir->file( $name . $lang_ext );
+        my $dest = $lang_dir->child( $name . $lang_ext );
         $plugin->log_fatal("$dest already exists") if -e $dest;
         run3 (
             [@cmd,  "--locale=$lang", '--output-file=' . $dest],

--- a/lib/Dist/Zilla/App/Command/msg_merge.pm
+++ b/lib/Dist/Zilla/App/Command/msg_merge.pm
@@ -5,7 +5,6 @@ package Dist::Zilla::App::Command::msg_merge;
 use Dist::Zilla::App -command;
 use strict;
 use warnings;
-use Path::Class;
 use Dist::Zilla::Plugin::LocaleTextDomain;
 use File::Basename;
 use Moose;

--- a/lib/Dist/Zilla/App/Command/msg_scan.pm
+++ b/lib/Dist/Zilla/App/Command/msg_scan.pm
@@ -6,6 +6,7 @@ use Dist::Zilla::App -command;
 use strict;
 use warnings;
 use Moose;
+use Path::Tiny;
 use namespace::autoclean;
 
 our $VERSION = '0.91';
@@ -49,11 +50,10 @@ sub validate_args {
 sub execute {
     my ( $self, $opt ) = @_;
 
-    require Path::Class;
     my $dzil     = $self->zilla;
     my $plugin   = $self->zilla->plugin_named('LocaleTextDomain')
         or $dzil->log_fatal('LocaleTextDomain plugin not found in dist.ini!');
-    my $pot_file = Path::Class::file($opt->{pot_file} || (
+    my $pot_file = path($opt->{pot_file} || (
         $plugin->lang_dir, $self->zilla->name . '.pot'
     ));
 

--- a/lib/Dist/Zilla/Role/PotFile.pm
+++ b/lib/Dist/Zilla/Role/PotFile.pm
@@ -5,7 +5,7 @@ package Dist::Zilla::Role::PotFile;
 use Moose::Role;
 use strict;
 use warnings;
-use Path::Class;
+use Path::Tiny;
 use namespace::autoclean;
 
 with 'Dist::Zilla::Role::PotWriter';
@@ -26,13 +26,13 @@ sub pot_file {
     my $plugin = $self->zilla->plugin_named('LocaleTextDomain')
         or $dzil->log_fatal('LocaleTextDomain plugin not found in dist.ini!');
 
-    $pot = file $plugin->lang_dir, $dzil->name . '.pot';
+    $pot = $plugin->lang_dir->child($dzil->name . '.pot');
     return $pot if -e $pot;
 
     # Create a temporary template file.
     require File::Temp;
     my $tmp = $self->{tmp} = File::Temp->new(SUFFIX => '.pot', OPEN => 0);
-    $pot = file $tmp->filename;
+    $pot = path $tmp->filename;
     $self->log('extracting gettext strings');
     $self->write_pot(
         to               => $pot,

--- a/lib/Dist/Zilla/Role/PotWriter.pm
+++ b/lib/Dist/Zilla/Role/PotWriter.pm
@@ -5,7 +5,6 @@ package Dist::Zilla::Role::PotWriter;
 use Moose::Role;
 use strict;
 use warnings;
-use File::Path qw(make_path);
 use IPC::Run3;
 use namespace::autoclean;
 
@@ -32,7 +31,7 @@ sub write_pot {
     my $verb = -e $pot ? 'update' : 'create';
 
     # Make sure the directory exists.
-    make_path $pot->parent->stringify unless -d $pot->parent;
+    $pot->parent->mkpath unless -d $pot->parent;
 
     # Need to do this before calling other methods, as they need the
     # files loaded to find various information.
@@ -117,7 +116,7 @@ language translation file. The supported parameters are:
 
 =item C<to>
 
-L<Path::Class::File> object representing the file to write to. Required.
+L<Path::Tiny> object representing the file to write to. Required.
 
 =item C<scan_files>
 

--- a/t/msg_compile.t
+++ b/t/msg_compile.t
@@ -5,7 +5,7 @@ use warnings;
 use Test::More 0.90;
 use Test::DZil;
 use IPC::Cmd 'can_run';
-use Path::Class;
+use Path::Tiny;
 use Test::File;
 use Test::File::Contents;
 use Dist::Zilla::App::Tester;
@@ -38,7 +38,7 @@ my $i = 0;
 for my $lang (qw(de fr)) {
     like $result->log_messages->[$i++], qr/(?:po.$lang[.]po: )?19/m,
         "$lang.po message should have been logged";
-    my $mo = file $result->tempdir,
+    my $mo = path $result->tempdir,
         qw(source LocaleData), $lang, qw(LC_MESSAGES DZT-Sample.mo);
     my $t = $result->tempdir;
     file_exists_ok $mo, "$lang .mo file should now exist";
@@ -47,19 +47,19 @@ for my $lang (qw(de fr)) {
 }
 
 # Try creating just one language.
-my $de = file qw(po de.po);
-my $fr = file qw(po fr.po);
+my $de = path qw(po de.po);
+my $fr = path qw(po fr.po);
 $result = test_dzil('t/dist', [qw(msg-compile), $fr]);
 is $result->exit_code, 0, '"msg-compile fr" should have exited 0';
 is @{ $result->log_messages }, 1, 'Should have only one log message';
 like $result->log_messages->[0], qr/(?:po.fr[.]po: )?19/m,
     '... And it should be for the french file';
-my $mo = file $result->tempdir,
+my $mo = path $result->tempdir,
     qw(source LocaleData fr LC_MESSAGES DZT-Sample.mo);
 file_exists_ok $mo, "fr .mo file should exist";
 file_contents_like $mo, qr/^Language: fr$/m,
     "f r.mo should have language content";
-$mo = file $result->tempdir,
+$mo = path $result->tempdir,
     qw(source LocaleData de LC_MESSAGES DZT-Sample.mo);
 file_not_exists_ok $mo, 'de .mo file should not exist';
 
@@ -71,7 +71,7 @@ $i = 0;
 for my $lang (qw(de fr)) {
     like $result->log_messages->[$i++], qr/(?:po.$lang[.]po: )?19/m,
         "$lang.po message should have been logged";
-    my $mo = file $result->tempdir,
+    my $mo = path $result->tempdir,
         qw(source foo LocaleData), $lang, qw(LC_MESSAGES DZT-Sample.mo);
     my $t = $result->tempdir;
     file_exists_ok $mo, "$lang .mo file should now exist";

--- a/t/msg_init.t
+++ b/t/msg_init.t
@@ -5,7 +5,7 @@ use warnings;
 use Test::More 0.90;
 use Test::DZil;
 use IPC::Cmd 'can_run';
-use Path::Class;
+use Path::Tiny;
 use Test::File;
 use Test::File::Contents;
 use Dist::Zilla::App::Tester;
@@ -60,7 +60,7 @@ ok((grep {
 ok((grep { /ja[.]po/} @{ $result->log_messages }),
    'File name should have been emitted from msginit');
 
-my $po = file $result->tempdir, qw(source po ja.po);
+my $po = path $result->tempdir, qw(source po ja.po);
 file_exists_ok $po, 'po/ja.po should now exist';
 file_contents_like $po, qr/Language: ja/,
     'Language name "ja" should be present';
@@ -80,7 +80,7 @@ like $result->error, qr/po.fr[.]po already exists/,
     'Should get error trying to create existing language';
 
 # Now specify a bunch of options.
-my $pot = file qw(po org.imperia.simplecal.pot);
+my $pot = path qw(po org.imperia.simplecal.pot);
 ok $result = test_dzil('t/dist', [
     'msg-init',
     '--encoding'         => 'Latin-1',
@@ -98,7 +98,7 @@ ok(!(grep {
 ok((grep { /pt_BR[.]po/} @{ $result->log_messages }),
    'pt_BR name should have been emitted from msginit');
 
-$po = file $result->tempdir, qw(source po pt_BR.po);
+$po = path $result->tempdir, qw(source po pt_BR.po);
 file_exists_ok $po, 'po/pt_BR.po should now exist';
 file_contents_like $po, qr/Language: pt_BR/,
     'Language name "pt_BR" should be present';

--- a/t/msg_merge.t
+++ b/t/msg_merge.t
@@ -5,7 +5,7 @@ use warnings;
 use Test::More 0.90;
 use Test::DZil;
 use IPC::Cmd 'can_run';
-use Path::Class;
+use Path::Tiny;
 use Test::File;
 use Test::File::Contents;
 use Dist::Zilla::App::Tester;
@@ -52,10 +52,10 @@ ok got_msg(qr/extracting gettext strings/),
     'Should have logged the POT file creation';
 
 for my $lang (qw(de fr)) {
-    my $po = file 'po', "$lang.po";
+    my $po = path 'po', "$lang.po";
     ok got_msg(qr/Merging gettext strings into $po/),
         "Should have message for merging $lang.po";
-    my $path = file $result->tempdir, qw(source po), "$lang.po";
+    my $path = path $result->tempdir, qw(source po), "$lang.po";
     file_exists_ok $path, "$po should exist";
     file_not_exists_ok "$path~", "$po~ should not exist";
     file_contents_like $path,
@@ -65,8 +65,8 @@ for my $lang (qw(de fr)) {
 }
 
 # Try specifying a file.
-my $de = file qw(po de.po);
-my $fr = file qw(po fr.po);
+my $de = path qw(po de.po);
+my $fr = path qw(po fr.po);
 ok $result = test_dzil('t/dist', [qw(msg-merge), $de, '--backup']),
     'Call msg-merge with de.po arg';
 is $result->exit_code, 0, 'Should have exited 0' or diag @{ $result->log_messages };
@@ -74,7 +74,7 @@ ok got_msg(qr/extracting gettext strings/),
     'Should have logged the POT file creation';
 
 # Make sure the German was merged.
-my $path = file $result->tempdir, 'source', $de;
+my $path = path $result->tempdir, 'source', $de;
 ok got_msg(qr/Merging gettext strings into $de/),
     "Should have message for merging $de";
 file_exists_ok $path, "$de should exist";
@@ -85,7 +85,7 @@ file_contents_like $path,
     qr/^\Q#~ msgid "May"\E$/m, qq{$de should have "May" msgid commented out};
 
 # The French should not have been merged.
-$path = file $result->tempdir, 'source', $fr;
+$path = path $result->tempdir, 'source', $fr;
 ok !got_msg(qr/Merging gettext strings into $fr/),
     "Should not have message for merging $fr";
 file_exists_ok $path, "$fr should exist";
@@ -96,11 +96,11 @@ file_contents_like $path,
     qr/^\Qmsgid "May"\E$/m, qq{$fr should have uncommented "May" msgid};
 
 # Now specify a bunch of options.
-my $pot = file qw(po org.imperia.simplecal.pot);
+my $pot = path qw(po org.imperia.simplecal.pot);
 ok $result = test_dzil('t/dist', [
     'msg-merge',
     '--encoding'         => 'Latin-1',
-    '--pot-file'         => file(qw(po org.imperia.simplecal.pot)),
+    '--pot-file'         => path(qw(po org.imperia.simplecal.pot)),
     '--copyright-holder' => 'Homer Simpson',
     '--bugs-email'       => 'foo@bar.com',
     '--backup',
@@ -111,10 +111,10 @@ ok !got_msg(qr/extracting gettext strings/),
     'Should not have logged the POT file creation';
 
 for my $lang (qw(de fr)) {
-    my $po = file 'po', "$lang.po";
+    my $po = path 'po', "$lang.po";
     ok got_msg(qr/Merging gettext strings into $po/),
         "Should have message for merging $lang.po";
-    my $path = file $result->tempdir, qw(source po), "$lang.po";
+    my $path = path $result->tempdir, qw(source po), "$lang.po";
     file_exists_ok $path, "$po should exist";
     file_not_exists_ok "$path~", "$po~ should not exist (no changes)";
     file_contents_unlike $path,
@@ -123,7 +123,7 @@ for my $lang (qw(de fr)) {
         qr/^\Qmsgid "May"\E$/m, qq{$po should have "May" msgid};
 }
 
-my $nonpot = file(qw(po nonexistent.top));
+my $nonpot = path(qw(po nonexistent.top));
 # Now try a non-existent POT file.
 ok $result = test_dzil('t/dist', [
     'msg-merge',

--- a/t/msg_scan.t
+++ b/t/msg_scan.t
@@ -5,7 +5,7 @@ use warnings;
 use Test::More 0.90;
 use Test::DZil;
 use IPC::Cmd 'can_run';
-use Path::Class;
+use Path::Tiny;
 use Test::File;
 use Test::File::Contents;
 use Dist::Zilla::App::Tester;
@@ -32,7 +32,7 @@ ok((grep {
     /extracting gettext strings into po.DZT-Sample[.]pot/
 } @{ $result->log_messages }),  'Should have logged the POT file creation');
 
-my $pot = file $result->tempdir, qw(source po DZT-Sample.pot);
+my $pot = path $result->tempdir, qw(source po DZT-Sample.pot);
 file_exists_ok $pot, 'po/DZT-Sample.pot should exist';
 file_contents_like $pot, qr/\QCopyright (C) YEAR David E. Wheeler/m,
     'po/DZT-Sample.pot should have copyright holder';
@@ -64,7 +64,7 @@ ok((grep {
     /extracting gettext strings into my[.]pot/
 } @{ $result->log_messages }),  'Should have logged the mo.pot creation');
 
-$pot = file $result->tempdir, qw(source my.pot);
+$pot = path $result->tempdir, qw(source my.pot);
 file_exists_ok $pot, 'my.pot should exist';
 file_contents_like $pot, qr/\QCopyright (C) YEAR Homer Simpson/m,
     'my.pot should have copyright holder';
@@ -88,7 +88,7 @@ ok((grep {
     /extracting gettext strings into po.DZT-Sample2[.]pot/
 } @{ $result->log_messages }),  'Should have logged the POT file creation');
 
-$pot = file $result->tempdir, qw(source po DZT-Sample2.pot);
+$pot = path $result->tempdir, qw(source po DZT-Sample2.pot);
 file_exists_ok $pot, 'po/DZT-Sample2.pot should exist';
 file_contents_like $pot,
     qr/bar[.]pl:6$/m,

--- a/t/plugin.t
+++ b/t/plugin.t
@@ -5,6 +5,7 @@ use warnings;
 use Test::More 0.90;
 use Test::DZil;
 use IPC::Cmd 'can_run';
+use Path::Tiny;
 
 plan skip_all => 'msgfmt not found' unless can_run 'msgfmt';
 
@@ -23,7 +24,7 @@ sub tzil {
     );
 }
 
-ok my $tzil = tzil(), 'Create tzil';;
+ok my $tzil = tzil(), 'Create tzil';
 
 ok $tzil->build, 'Build it';
 my @messages = grep { /^\Q[LocaleTextDomain]/ } @{ $tzil->log_messages };
@@ -65,9 +66,9 @@ ok $tzil->build, 'Build again';
 is $messages[0], '[LocaleTextDomain] Compiling language files in po',
     'Compiling message should have been emitted again';
 
-ok -e $tzil->tempdir->file("build/lib/LocaleData/fr/LC_MESSAGES/org.imperia.simplecal.bo"),
+ok -e path($tzil->tempdir)->child("build/lib/LocaleData/fr/LC_MESSAGES/org.imperia.simplecal.bo"),
     'Should have fr .bo file';
-ok !-e $tzil->tempdir->file("build/lib/LocaleData/de/LC_MESSAGES/org.imperia.simplecal.bo"),
+ok !-e path($tzil->tempdir)->child("build/lib/LocaleData/de/LC_MESSAGES/org.imperia.simplecal.bo"),
     'Should not have de .bo file';
 
 $i = 0;


### PR DESCRIPTION
This solution may be a bit heavy-handed -- if so, there's an easy alternative already prepared -- but I converted **everything** to Path::Tiny to get rid of deprecation warnings in the tests related to treating Dist::Zilla::Path as a Path::Class. There's a temporary shim in place now, but apparently in DZ v7 that's going away, so it'd be good to fix this sooner.

Here's a smaller alternative if you want to keep using Path::Class: https://github.com/chazmcgarvey/dist-zilla-localetextdomain/tree/ccm-remove-deprecated-use-of-file-method-2