### PR TITLE
New attributes: xgettext_args, override_args, join_existing

### DIFF
--- a/lib/Dist/Zilla/Plugin/LocaleTextDomain.pm
+++ b/lib/Dist/Zilla/Plugin/LocaleTextDomain.pm
@@ -26,6 +26,18 @@ BEGIN {
     subtype 'App', as 'Str', where { !!can_run $_ },  message {
         qq{Cannot find "$_": Are the GNU gettext utilities installed?};
     };
+
+    subtype 'ShellWords', as 'ArrayRef[Str]';
+    coerce  'ShellWords', from 'Str', via {
+        require Text::ParseWords;
+        [Text::ParseWords::shellwords($_)];
+    };
+
+    subtype 'ArrayRefOfShellWords', as 'ArrayRef[ShellWords]';
+    coerce  'ArrayRefOfShellWords', from 'ArrayRef[Str]', via {
+        require Text::ParseWords;
+        [map { [Text::ParseWords::shellwords($_)] } @$_];
+    };
 }
 
 has textdomain => (
@@ -76,6 +88,26 @@ has bin_file_suffix => (
     default => 'mo',
 );
 
+has xgettext_args => (
+    is      => 'ro',
+    isa     => 'ShellWords',
+    coerce  => 1,
+    default => sub { [] },
+);
+
+has override_args => (
+    is      => 'ro',
+    isa     => 'Bool',
+    default => 0,
+);
+
+has join_existing => (
+    is      => 'ro',
+    isa     => 'ArrayRefOfShellWords',
+    coerce  => 1,
+    default => sub { [] },
+);
+
 has language => (
     is      => 'ro',
     isa     => 'ArrayRef[Str]',
@@ -94,7 +126,7 @@ has language => (
     },
 );
 
-sub mvp_multivalue_args { return qw(language) }
+sub mvp_multivalue_args { return qw(join_existing language) }
 
 sub gather_files {
     my ($self, $arg) = @_;
@@ -287,6 +319,49 @@ L<C<FileFinder>|Dist::Zilla::Role::FileFinder> plugin. For example:
 
 This configuration will extract strings from files that match C<*.pl> and all
 files in a share directory.
+
+=head3 C<xgettext_args>
+
+Extra arguments to be passed to the extractor program. This is an advanced
+feature that exists for cases where special customization is needed, such as
+when different keywords are used to mark strings.
+
+=head3 C<override_args>
+
+By default, arguments are passed to the extractor that set the language to
+"perl" as well as set keywords that tell L<xgettext> how strings are marked
+(which includes the keywords specified by L<Locale::TextDomain>). If for some
+reason you don't want that (presumably because you're going to use the
+C<xgettext_args> attribute to configure your own language and keywords), then
+you can set this attribute to true.
+
+=head3 C<join_existing>
+
+If you have strings in files other than Perl files, you can cause the
+extractor to be invoked multiple times against different sets of files with
+different arguments. The strings from all of these other file sets will be
+joined into your C<po> files.
+
+For example, imagine you have a GTK+ app. You have strings in your Perl
+modules, as usual, but perhaps you also have strings in your Glade files that
+you want to be translatable. You could write something like this into your
+F<dist.ini>:
+
+  [FileFinder::ByName / GladeFiles]
+  file = *.ui
+
+  [LocaleTextDomain]
+  join_existing = --language=glade %{GladeFiles}f
+
+The value of the C<join_existing> attribute is the argument list that will be
+passed to an additional invocation of L<xgettext>. The C<%{GladeFiles}f>
+syntax allows you to use a finder to search for files to be passed to the
+extractor, but you could also "hard code" one or more files as well.
+
+This attribute is repeatable. If your project also had a JavaScript file with
+strings, you could just add another line to your C<LocaleTextDomain> section:
+
+  join_existing = -L javascript share/media/app.js
 
 =head1 Author
 

--- a/t/base.t
+++ b/t/base.t
@@ -6,7 +6,7 @@ use Test::More tests => 14;
 
 require_ok 'Dist::Zilla::Plugin::LocaleTextDomain';
 is_deeply [Dist::Zilla::Plugin::LocaleTextDomain->mvp_multivalue_args],
-    [qw(language finder)], 'Should have mvp_multivalue_args';
+    [qw(join_existing language finder)], 'Should have mvp_multivalue_args';
 
 for my $cmd (qw(msg_init msg_scan msg_merge msg_compile)) {
     my $module = "Dist::Zilla::App::Command::$cmd";

--- a/t/dist3/bin/myprog.pl
+++ b/t/dist3/bin/myprog.pl
@@ -1,0 +1,9 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+__ "Foo";
+FOO "Bar";
+
+1;

--- a/t/dist3/dist.ini
+++ b/t/dist3/dist.ini
@@ -1,0 +1,10 @@
+name = DZT-Sample3
+version = 1.2
+license = Perl_5
+author = David E. Wheeler <david@justatheory.com>
+copyright_holder = David E. Wheeler
+
+[@Basic]
+
+[LocaleTextDomain]
+xgettext_args = --keyword=FOO

--- a/t/dist4/bin/myprog.pl
+++ b/t/dist4/bin/myprog.pl
@@ -1,0 +1,9 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+__ "Foo";
+FOO "Bar";
+
+1;

--- a/t/dist4/dist.ini
+++ b/t/dist4/dist.ini
@@ -1,0 +1,11 @@
+name = DZT-Sample4
+version = 1.2
+license = Perl_5
+author = David E. Wheeler <david@justatheory.com>
+copyright_holder = David E. Wheeler
+
+[@Basic]
+
+[LocaleTextDomain]
+xgettext_args = --keyword=FOO
+override_args = 1

--- a/t/dist5/bin/myprog.pl
+++ b/t/dist5/bin/myprog.pl
@@ -1,0 +1,8 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+__ "Foo";
+
+1;

--- a/t/dist5/dist.ini
+++ b/t/dist5/dist.ini
@@ -1,0 +1,14 @@
+name = DZT-Sample5
+version = 1.2
+license = Perl_5
+author = David E. Wheeler <david@justatheory.com>
+copyright_holder = David E. Wheeler
+
+[@Basic]
+
+[FileFinder::ByName / CFiles]
+file = mars.c
+
+[LocaleTextDomain]
+join_existing = -L Glade jupiter.ui
+join_existing = -L C %{CFiles}f

--- a/t/dist5/jupiter.ui
+++ b/t/dist5/jupiter.ui
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.20.0 -->
+<interface domain="myprog">
+  <requires lib="gtk+" version="3.20"/>
+  <object class="GtkEntryBuffer" id="entrybuffer1">
+    <property name="text" translatable="yes">Bar</property>
+  </object>
+</interface>

--- a/t/dist5/mars.c
+++ b/t/dist5/mars.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+#include <libintl.h>
+int main() {
+    printf(gettext("Baz"));
+    return 0;
+}

--- a/t/msg_scan.t
+++ b/t/msg_scan.t
@@ -37,19 +37,19 @@ file_exists_ok $pot, 'po/DZT-Sample.pot should exist';
 file_contents_like $pot, qr/\QCopyright (C) YEAR David E. Wheeler/m,
     'po/DZT-Sample.pot should have copyright holder';
 file_contents_like $pot, qr/^\Q"Project-Id-Version: DZT-Sample 1.2\n"\E$/m,
-    'po/DZT-Sample.pot should exist should have project ID and version';
+    'po/DZT-Sample.pot should have project ID and version';
 file_contents_like $pot,
     qr/^\Q"Report-Msgid-Bugs-To: david\E[@]\Qjustatheory.com\n"\E$/m,
-    'po/DZT-Sample.pot should exist should have bugs email';
+    'po/DZT-Sample.pot should have bugs email';
 file_contents_like $pot,
     qr/^\Qmsgid "Hi"\E$/m,
-    'po/DZT-Sample.pot should exist should have "Hi" msgid';
+    'po/DZT-Sample.pot should have "Hi" msgid';
 file_contents_like $pot,
     qr/^\Qmsgid "Bye"\E$/m,
-    'po/DZT-Sample.pot should exist should have "Bye" msgid';
+    'po/DZT-Sample.pot should have "Bye" msgid';
 file_contents_like $pot,
     qr/^\Qmsgid "Foo"\E$/m,
-    'po/DZT-Sample.pot should exist should have "Foo" msgid';
+    'po/DZT-Sample.pot should have "Foo" msgid';
 
 # Try setting some stuff.
 $result = test_dzil('t/dist', [qw(
@@ -69,16 +69,16 @@ file_exists_ok $pot, 'my.pot should exist';
 file_contents_like $pot, qr/\QCopyright (C) YEAR Homer Simpson/m,
     'my.pot should have copyright holder';
 file_contents_like $pot, qr/^\Q"Project-Id-Version: DZT-Sample 1.2\n"\E$/m,
-    'my.pot should exist should have project ID and version';
+    'my.pot should have project ID and version';
 file_contents_like $pot,
     qr/^\Q"Report-Msgid-Bugs-To: homer\E[@]\Qexample.com\n"\E$/m,
-    'my.pot should exist should have custom bugs email';
+    'my.pot should have custom bugs email';
 file_contents_like $pot,
     qr/^\Qmsgid "Hi"\E$/m,
-    'my.pot should exist should have "Hi" msgid';
+    'my.pot should have "Hi" msgid';
 file_contents_like $pot,
     qr/^\Qmsgid "Bye"\E$/m,
-    'my.pot should exist should have "Bye" msgid';
+    'my.pot should have "Bye" msgid';
 
 # Use finder attribute
 $result = test_dzil('t/dist2', [qw(msg-scan)]);
@@ -95,12 +95,87 @@ file_contents_like $pot,
     'po/DZT-Sample2.pot should have entry for "bar.pl" file';
 file_contents_like $pot,
     qr/^\Qmsgid "Bar"\E$/m,
-    'po/DZT-Sample2.pot should exist should have "Bar" msgid';
+    'po/DZT-Sample2.pot should have "Bar" msgid';
 file_contents_like $pot,
     qr/Config[.]pm:6$/m,
     'po/DZT-Sample2.pot should have entry for "Config.pm" file';
 file_contents_like $pot,
     qr/^\Qmsgid "Foo"\E$/m,
-    'po/DZT-Sample2.pot should exist should have "Foo" msgid';
+    'po/DZT-Sample2.pot should have "Foo" msgid';
+
+# Use xgettext_args attribute
+$result = test_dzil('t/dist3', [qw(msg-scan)]);
+is $result->exit_code, 0, "dzil would have exited 0" or diag @{ $result->log_messages };
+
+ok((grep {
+    /extracting gettext strings into po.DZT-Sample3[.]pot/
+} @{ $result->log_messages }),  'Should have logged the POT file creation');
+
+$pot = file $result->tempdir, qw(source po DZT-Sample3.pot);
+file_exists_ok $pot, 'po/DZT-Sample3.pot should exist';
+file_contents_like $pot,
+    qr/myprog[.]pl:6$/m,
+    'po/DZT-Sample3.pot should have entry for "myprog.pl" file';
+file_contents_like $pot,
+    qr/^\Qmsgid "Foo"\E$/m,
+    'po/DZT-Sample3.pot should have "Foo" msgid';
+file_contents_like $pot,
+    qr/myprog[.]pl:7$/m,
+    'po/DZT-Sample3.pot should have entry for "myprog.pl" file';
+file_contents_like $pot,
+    qr/^\Qmsgid "Bar"\E$/m,
+    'po/DZT-Sample3.pot should have "Bar" msgid';
+
+# Use override_args attribute
+$result = test_dzil('t/dist4', [qw(msg-scan)]);
+is $result->exit_code, 0, "dzil would have exited 0" or diag @{ $result->log_messages };
+
+ok((grep {
+    /extracting gettext strings into po.DZT-Sample4[.]pot/
+} @{ $result->log_messages }),  'Should have logged the POT file creation');
+
+$pot = file $result->tempdir, qw(source po DZT-Sample4.pot);
+file_exists_ok $pot, 'po/DZT-Sample4.pot should exist';
+file_contents_unlike $pot,
+    qr/myprog[.]pl:6$/m,
+    'po/DZT-Sample4.pot should have "Foo" entry for "myprog.pl" file';
+file_contents_unlike $pot,
+    qr/^\Qmsgid "Foo"\E$/m,
+    'po/DZT-Sample4.pot should not have "Foo" msgid';
+file_contents_like $pot,
+    qr/myprog[.]pl:7$/m,
+    'po/DZT-Sample4.pot should have entry for "myprog.pl" file';
+file_contents_like $pot,
+    qr/^\Qmsgid "Bar"\E$/m,
+    'po/DZT-Sample4.pot should have "Bar" msgid';
+
+# Use join_existing attribute
+$result = test_dzil('t/dist5', [qw(msg-scan)]);
+is $result->exit_code, 0, "dzil would have exited 0" or diag @{ $result->log_messages };
+
+ok((grep {
+    /extracting gettext strings into po.DZT-Sample5[.]pot/
+} @{ $result->log_messages }),  'Should have logged the POT file creation');
+
+$pot = file $result->tempdir, qw(source po DZT-Sample5.pot);
+file_exists_ok $pot, 'po/DZT-Sample5.pot should exist';
+file_contents_like $pot,
+    qr/myprog[.]pl:6$/m,
+    'po/DZT-Sample5.pot should have entry for "myprog.pl" file';
+file_contents_like $pot,
+    qr/^\Qmsgid "Foo"\E$/m,
+    'po/DZT-Sample5.pot should have "Foo" msgid';
+file_contents_like $pot,
+    qr/jupiter[.]ui:6/m,
+    'po/DZT-Sample5.pot should have entry for "jupiter.ui" file';
+file_contents_like $pot,
+    qr/^\Qmsgid "Bar"\E$/m,
+    'po/DZT-Sample5.pot should have "Bar" msgid';
+file_contents_like $pot,
+    qr/mars[.]c:4/m,
+    'po/DZT-Sample5.pot should have entry for "mars.c" file';
+file_contents_like $pot,
+    qr/^\Qmsgid "Baz"\E$/m,
+    'po/DZT-Sample5.pot should have "Baz" msgid';
 
 done_testing;


### PR DESCRIPTION
I implemented a few new attributes in order to make it easier to override or augment extraction details (see #2). I've started using D::Z::LocaleTextDomain in a new project, and these new attributes (esp. `join_existing`) are useful to me so far. Please take a look and offer feedback. The pod has the skinny.