### PR TITLE
Do not depend on insecure module Email::Address

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ utilities. It also requires the following non-core modules:
 * Dist::Zilla
 * Dist::Zilla::File::FromCode
 * Dist::Zilla::Role::FileGatherer
-* Email::Address
+* Email::Address::XS
 * Encode
 * File::Find::Rule
 * IPC::Cmd

--- a/lib/Dist/Zilla/Role/PotFile.pm
+++ b/lib/Dist/Zilla/Role/PotFile.pm
@@ -129,7 +129,7 @@ configured for L<Dist::Zilla>.
 
 Email address for reporting translation bugs. Defaults to the email address of
 the first author known to L<Dist::Zilla>, if available and parseable by
-L<Email::Address>.
+L<Email::Address::XS>.
 
 =back
 

--- a/lib/Dist/Zilla/Role/PotWriter.pm
+++ b/lib/Dist/Zilla/Role/PotWriter.pm
@@ -6,6 +6,7 @@ use Moose::Role;
 use strict;
 use warnings;
 use IPC::Run3;
+use Email::Address::XS 1.01;
 use namespace::autoclean;
 
 our $VERSION = '0.92';
@@ -41,9 +42,8 @@ sub write_pot {
 
     my $email = $p{bugs_email} || do {
         if (my $author = $dzil->authors->[0]) {
-            require Email::Address;
-            my ($addr) = Email::Address->parse($author);
-            $addr->address if $addr;
+            my $addr = Email::Address::XS->parse($author);
+            $addr->address if $addr->is_valid;
         }
     } || '';
 
@@ -185,7 +185,7 @@ configured for L<Dist::Zilla>.
 
 Email address for reporting translation bugs. Defaults to the email address of
 the first author known to L<Dist::Zilla>, if available and parseable by
-L<Email::Address>.
+L<Email::Address::XS>.
 
 =back
 


### PR DESCRIPTION
Module Email::Address is vulnerable to CVE-2015-7686 and new replacement is
module Email::Address::XS.